### PR TITLE
removed text from landing page, moved to intro app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ All you need to do is to write your own streamlit apps and they will be accessib
 
 # How to start
 
-Let's go ahead and create, run and publish a small testing app. 
+Here are some quick video guides on [how to contribute via GitHub](https://youtu.be/LesKQw3Fbs0) and [how to write a basic app](https://youtu.be/98_n4WRdXnM) if you prefer that to reading.
+
+If not, let's go ahead and create, run and publish a small testing app. 
 
 > If you just want to see the final result, check [this python file](/apps/001_template/app.py) which creates 
 [this live app](https://share.stlite.net/#url=https://raw.githubusercontent.com/SocialFinanceDigitalLabs/patch/main/apps/001_template/app.py).

--- a/apps/000_intro/app.py
+++ b/apps/000_intro/app.py
@@ -8,8 +8,19 @@ st.markdown(
     """
 ### PATCh
 
-This editor uses **stlite** is a port of _Streamlit_ to Wasm, powered by Pyodide,
-that runs completely on web browsers.
+For those interested in how PATCh apps work: every time you load a PATCh app, the webpage will use something called Pyodide to run
+Python in the browser. The product of the Python code is then displayed as HTML using a package called streamlit lite.
+This only outside connection the apps make is the initial setup to run Python in the browser. It uses **stlite**, which is is a port of
+_Streamlit_ to Wasm, powered by Pyodide,
+that runs completely on web browsers. Once an app is running it's self contained,
+you could even test this by running apps with the internet turned off once they've loaded. Pyodide uses your browser's memory 
+and other resources to run the Python code making up the apps on your computer. This is unlike many other apps which would run the Python 
+on a server somewhere and send information back and forth, which is why you can't use confidential data with them. The way streamlit 
+lite works is that every time you do something in the app, it re-runs the Python code from the beginning (not including the install). 
+This allows it to be easier to write for analysts, but does mean some apps take a while to update between widget interractions.
+
+
+
 
 To contribute to PATCh apps, see it's documentation [here](https://github.com/SocialFinanceDigitalLabs/patch/blob/main/README.md).
 The official stlite repository is [🔗 here](https://github.com/whitphx/stlite).

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,29 +18,21 @@
     </div>
     <section>
       <p>
-        The PATCh tool is a set of open source data analysis and visualisation apps made by analysts from various authorities nationally
+        The Python Analysis Toolkit for CHildrens services (PATCh) is a set of open source data analysis and visualisation apps made by analysts from various authorities nationally
         with Python teaching and development from from Data to Insight and development from Social Finance. The apps run entirely in the 
         browser, without sending data to any servers. This means that it's safe to use data in any app as it does not leave your computer. 
       </p>
       <p>
-        A video demo of PATCh can be found here: LINK WHEN MADE
-      </p>
-      <p>
-        If you have questions about the PATCh tool, free Python learning from D2I, any apps, or want to know
+        If you have questions about PATCh, free Python learning from D2I, any apps, or want to know
         more about how to contribute, contact data to insight at: datatoinsight.enquiries@gmail.com
       </p>
       <p>
-        A video guide on how to contribute can be found here: LINK WHEN MADE
-      </p>
-      <p>
-        For those interested in how the PATCh tool works: every time you load a PATCh app, the webpage will use something called Pyodide to run
-        Python in the browser. The product of the Python code is then displayed as HTML using a package called streamlit lite.
-        This only outside connection the apps make is the initial setup to run Python in the browser. Once an app is running it's self contained,
-        you could even test this by running apps with the internet turned off once they've loaded. Pyodide uses your browser's memory 
-        and other resources to run the Python code making up the apps on your computer. This is unlike many other apps which would run the Python 
-        on a server somewhere and send information back and forth, which is why you can't use confidential data with them. The way streamlit 
-        lite works is that every time you do something in the app, it re-runs the Python code from the beginning (not including the install). 
-        This allows it to be easier to write for analysts, but does mean some apps take a while to update between widget interractions.
+        Info on how to contribute, including video guides on writing apps and using GitHub can be found         
+        <a
+        href="https://www.datatoinsight.org/patch"
+        target="_blank"
+        >here</a
+      >.
       </p>
       <p>
         Data to Insight is a national project led by local authorities with
@@ -51,6 +43,14 @@
         To learn how to create an app click
         <a
           href="https://github.com/SocialFinanceDigitalLabs/patch/blob/main/README.md"
+          target="_blank"
+          >here</a
+        >.
+      </p>
+      <p>
+        For more detailed info on PATCh and how it works, click
+        <a
+          href="https://share.stlite.net/#url=https://raw.githubusercontent.com/data-to-insight/patch/main/apps/000_intro/app.py"
           target="_blank"
           >here</a
         >.


### PR DESCRIPTION
Moves some necessary but too long text from the landing page to the intro app, adds links to tutorial videos, and adds video links to readme